### PR TITLE
add sender configuration options for NAT masq

### DIFF
--- a/esmtprc.5
+++ b/esmtprc.5
@@ -43,6 +43,20 @@ type "localhost:smtp" or "localhost:25" where the application
 expects a host name.
 
 .TP
+\fBsender\fR
+Set the identity of the sender of the email.
+
+This is useful for systems behind a NAT firewall, when for example
+the sender's email address should not have the hostname.  Several
+escape formatting codes are available:
+
+   %u - user name of the sender
+   %h - hostname of the sending system
+   %d - domainname of the sending system
+
+So %u@%d might be a desirable identity from inside the local network.
+
+.TP
 \fBusername\fR
 Set the username for authentication with the SMTP server.
 

--- a/parser.y
+++ b/parser.y
@@ -104,6 +104,7 @@ statement_list	: statement
 
 /* future global options should also have the form SET <name> optmap <value> */
 statement	: HOSTNAME map STRING	{ identity->host = xstrdup($3); SET_DEFAULT_IDENTITY; }
+                | SENDER map STRING     { identity->address = xstrdup($3); }
 		| USERNAME map STRING	{ identity->user = xstrdup($3); SET_DEFAULT_IDENTITY; }
 		| PASSWORD map STRING	{ identity->pass = xstrdup($3); SET_DEFAULT_IDENTITY; }
 		| STARTTLS map DISABLED	{ identity->starttls = Starttls_DISABLED; SET_DEFAULT_IDENTITY; }


### PR DESCRIPTION
this patch adds a sender option to the config file.  it can be used to configure the sender identity for systems behind a NAT firewall.  For example, in a system whose hostname is host.domain, a default esmtprc:

hostname gateway:25
sender %u@%d

would specify that the sender identity would be identified username@domain rather than the default user@hostname.
